### PR TITLE
Make session creation and removal safer

### DIFF
--- a/src/diduhless/parties/listener/SessionListener.php
+++ b/src/diduhless/parties/listener/SessionListener.php
@@ -13,12 +13,23 @@ use pocketmine\event\player\PlayerQuitEvent;
 
 class SessionListener implements Listener {
 
+    /**
+     * @param PlayerLoginEvent $event
+     * @priority HIGHEST
+     * @ignoreCancelled
+     */
     public function onLogin(PlayerLoginEvent $event): void {
         SessionFactory::createSession($event->getPlayer());
     }
 
+    /**
+     * @param PlayerQuitEvent $event
+     * @priority LOWEST
+     */
     public function onQuit(PlayerQuitEvent $event): void {
-        SessionFactory::removeSession($event->getPlayer());
+        if(SessionFactory::hasSession($player = $event->getPlayer())) {
+            SessionFactory::removeSession($player);
+        }
     }
 
 }

--- a/src/diduhless/parties/session/SessionFactory.php
+++ b/src/diduhless/parties/session/SessionFactory.php
@@ -14,20 +14,34 @@ class SessionFactory {
     /** @var Session[] */
     static private $sessions = [];
 
-    static public function getSession(Player $player): ?Session {
-        return self::getSessionByName($player->getName()) ?? null;
-    }
-
     static public function getSessionByName(string $username): ?Session {
         return self::$sessions[$username] ?? null;
     }
 
+    static public function getSession(Player $player): ?Session {
+        return self::getSessionByName($player->getName()) ?? null;
+    }
+
+    static public function hasSession(Player $player): bool {
+        return array_key_exists($player->getName(), self::$sessions);
+    }
+
     static public function createSession(Player $player): void {
-        self::$sessions[$player->getName()] = $player;
+        $username = $player->getName();
+        if(self::hasSession($player)) {
+           throw new \InvalidArgumentException("Can't open a session for $username because they already have one");
+        } else {
+            self::$sessions[$username] = $player;
+        }
     }
 
     static public function removeSession(Player $player): void {
-        unset(self::$sessions[$player->getName()]);
+        $username = $player->getName();
+        if(self::hasSession($player)) {
+            unset(self::$sessions[$username]);
+        } else {
+            throw new \InvalidArgumentException("Can't remove $username's session because they don't have an open session");
+        }
     }
 
 }


### PR DESCRIPTION
## About the PR

Right now, the sessions are removed on a very unsafe way (it doesn't even check if the player has a session).

https://github.com/Diduhless/Parties/blob/e9565ba148c5a4beee68b0a9efde5a6697178b81/src/diduhless/parties/listener/SessionListener.php#L20-L22

This PR attempts to increase session creation and removal safety while increasing flexibility for third party developers.

## Changes

### SessionListener

onLogin() priority was set to highest and uses the tag `@ignoreCancelled`to prevent Parties from creating a session for a player that will be immediately disconnected.

onQuit() priority was set to lowest, allowing third party plugin developers to use Sessions on this event without specifying a higher priority. The listener also checks whether the session exists before trying to remove it.

### SessionFactory

Added the (static) function hasSession() to let third party developers check if a session exists and additionally reuse code internally.

Both createSession() and removeSession() throw exceptions now if they are used improperly.

